### PR TITLE
[Need Test] Update enable_ai.sh 修复运行不成功问题 但是需要测试

### DIFF
--- a/enable_ai.sh
+++ b/enable_ai.sh
@@ -331,7 +331,9 @@ while [ $SECONDS_PASSED -lt $MAX_WAIT_TIME ]; do
     sudo lldb --batch \
     -o "process attach --name eligibilityd" \
     -o "expression (void) [[[InputManager sharedInstance] objectForInputValue:6] setValue:@\"LL\" forKey:@\"_deviceRegionCode\"]" \
-    -o "expression -l objc -- @import Foundation; id $e = [EligibilityEngine sharedInstance]; NSArray<NSString*> *sels = @[@\"_onQueue_recomputeAllDomainAnswers\", @\"recomputeAllDomainAnswers\"]; for (NSString *selName in sels) { SEL sel = NSSelectorFromString(selName); if ([(NSObject *)$e respondsToSelector:sel]) { (void)[(NSObject *)$e performSelector:sel]; NSLog(@\"%@ performed\", selName); break; } }" \
+    -o "expression -l objc -- @import Foundation" \
+    -o "expression -l objc -- id engine = [EligibilityEngine sharedInstance]; if (engine != nil && [(NSObject*)engine respondsToSelector:@selector(recomputeAllDomainAnswers)]) { [(NSObject*)engine performSelector:@selector(recomputeAllDomainAnswers)]; NSLog(@\"recomputeAllDomainAnswers performed\"); }" \
+    -o "expression -l objc -- id engine = [EligibilityEngine sharedInstance]; if (engine != nil && [(NSObject*)engine respondsToSelector:@selector(_onQueue_recomputeAllDomainAnswers)]) { [(NSObject*)engine performSelector:@selector(_onQueue_recomputeAllDomainAnswers)]; NSLog(@\"_onQueue_recomputeAllDomainAnswers performed\"); }" \
     -o "process detach" \
     -o quit
 


### PR DESCRIPTION
我换了语法重新写了一个版本。

将关键代码改为如下：
```
    sudo lldb --batch \
    -o "process attach --name eligibilityd" \
    -o "expression (void) [[[InputManager sharedInstance] objectForInputValue:6] setValue:@\"LL\" forKey:@\"_deviceRegionCode\"]" \
    -o "expression -l objc -- @import Foundation" \
    -o "expression -l objc -- id engine = [EligibilityEngine sharedInstance]; if (engine != nil && [(NSObject*)engine respondsToSelector:@selector(recomputeAllDomainAnswers)]) { [(NSObject*)engine performSelector:@selector(recomputeAllDomainAnswers)]; NSLog(@\"recomputeAllDomainAnswers performed\"); }" \
    -o "expression -l objc -- id engine = [EligibilityEngine sharedInstance]; if (engine != nil && [(NSObject*)engine respondsToSelector:@selector(_onQueue_recomputeAllDomainAnswers)]) { [(NSObject*)engine performSelector:@selector(_onQueue_recomputeAllDomainAnswers)]; NSLog(@\"_onQueue_recomputeAllDomainAnswers performed\"); }" \
    -o "process detach" \
    -o quit
```


我仔细检查了，认为没有问题。 但是我在15.5的虚拟机环境下会运行报错

```
(lldb) process attach --name eligibilityd
Process 6706 stopped
* thread #1, stop reason = signal SIGSTOP
    frame #0: 0x00007ff8189c491a libsystem_kernel.dylib`__sigsuspend_nocancel + 10
libsystem_kernel.dylib`__sigsuspend_nocancel:
->  0x7ff8189c491a <+10>: jae    0x7ff8189c4924 ; <+20>
    0x7ff8189c491c <+12>: movq   %rax, %rdi
    0x7ff8189c491f <+15>: jmp    0x7ff8189bf29a ; cerror_nocancel
    0x7ff8189c4924 <+20>: retq   
Target 0: (eligibilityd) stopped.
Executable binary set to "/usr/libexec/eligibilityd".
Architecture set to: x86_64-apple-macosx-.
(lldb) expression (void) [[[InputManager sharedInstance] objectForInputValue:6] setValue:@"LL" forKey:@"_deviceRegionCode"]
(lldb) expression -l objc -- @import Foundation
(lldb) expression -l objc -- id engine = [EligibilityEngine sharedInstance]; if (engine != nil && [(NSObject*)engine respondsToSelector:@selector(recomputeAllDomainAnswers)]) { [(NSObject*)engine performSelector:@selector(recomputeAllDomainAnswers)]; NSLog(@"recomputeAllDomainAnswers performed"); }
(lldb) expression -l objc -- id engine = [EligibilityEngine sharedInstance]; if (engine != nil && [(NSObject*)engine respondsToSelector:@selector(_onQueue_recomputeAllDomainAnswers)]) { [(NSObject*)engine performSelector:@selector(_onQueue_recomputeAllDomainAnswers)]; NSLog(@"_onQueue_recomputeAllDomainAnswers performed"); }
                             
error: Execution was interrupted, reason: EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0).
The process has been returned to the state before expression evaluation.
```

这个错误并不是由我修改后的代码引起的，是在 [[EligibilityEngine sharedInstance]  XXXXX] 函数执行过程中出了异常，我更怀疑是 虚拟机环境、或者是因为我当前测试使用的是x86_64（不是ARM64）等各种外部原因引起的。

所以这个commit，需要测试一下。 如果在你们的设备中运行成功，则可以放心merge。

如果依然报错，再 @parkerjj  我。