### PR TITLE
Fix: Use xcrun to ensure correct lldb path

### DIFF
--- a/enable_ai.sh
+++ b/enable_ai.sh
@@ -340,7 +340,7 @@ while [ $SECONDS_PASSED -lt $MAX_WAIT_TIME ]; do
     PROCESS_FOUND=1 # Mark that the process was found
     # Use sudo for lldb as it needs elevated privileges to attach to system processes
     # set -e will cause the script to exit if the sudo lldb command itself fails critically.
-    sudo lldb --batch \
+    sudo -E "$(xcrun --find lldb)" --batch \
     -o "process attach --name eligibilityd" \
     -o "expression (void) [[[InputManager sharedInstance] objectForInputValue:6] setValue:@\"LL\" forKey:@\"_deviceRegionCode\"]" \
     -o "expression (void) [[EligibilityEngine sharedInstance] recomputeAllDomainAnswers]" \


### PR DESCRIPTION
Updated the script to use `$(xcrun --find lldb)` instead of just `lldb` to avoid affecting path changing by other tools and use -E flag to maintain the existing environment variables from current user.